### PR TITLE
Prometheus metrics

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,109 @@
+package radish
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/kansaslabs/x/out"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	pmWorkers        prometheus.Gauge         // number of available workers
+	pmQueueSize      prometheus.Gauge         // number of tasks in the queue awaiting handling
+	pmPercentFull    prometheus.Gauge         // the percent of the queue that is full * 100
+	pmPercentSuccess *prometheus.GaugeVec     // the percent of tasks successfully completed, labeled by task
+	pmTasksSucceeded *prometheus.CounterVec   // the count of successfully completed tasks, labeled by task type
+	pmTasksFailed    *prometheus.CounterVec   // the count of failed tasks, labeled by task type
+	pmTaskLatency    *prometheus.HistogramVec // the time it is taking for tasks to complete, labeled by task type, success, and failure
+)
+
+const (
+	pmNamespace = "radish"
+	pmSubsystem = "queue"
+)
+
+func initMetrics() {
+	pmWorkers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "workers",
+		Help:      "The number of available workers",
+	})
+
+	pmQueueSize = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "queue_size",
+		Help:      "number of tasks in the queue awaiting handling",
+	})
+
+	pmPercentFull = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "percent_full",
+		Help:      "the percent of the queue that is already full",
+	})
+
+	pmPercentSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "percent_success",
+		Help:      "the percent of tasks successfully completed, labeled by task",
+	}, []string{"task"})
+
+	pmTasksSucceeded = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "tasks_succeeded",
+		Help:      "the count of tasks successfully completed, labeled by task type",
+	}, []string{"task"})
+
+	pmTasksFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "tasks_failed",
+		Help:      "the count of failed tasks, labeled by task type",
+	}, []string{"task"})
+
+	pmTaskLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: pmNamespace,
+		Subsystem: pmSubsystem,
+		Name:      "task_latency",
+		Help:      "time to task completion, labeled by task type, success, and failure",
+	}, []string{"task", "result"})
+}
+
+func serveMetrics(metricsAddr string) {
+	out.Status("serving prometheus metrics at http://%s/metrics", metricsAddr)
+	http.Handle("/metrics", promhttp.Handler())
+	if err := http.ListenAndServe(metricsAddr, nil); err != nil {
+		out.Warne(err)
+	}
+}
+
+func registerMetrics() error {
+	if err := prometheus.Register(pmWorkers); err != nil {
+		return fmt.Errorf("did not register %s", pmWorkers, err)
+	}
+	if err := prometheus.Register(pmQueueSize); err != nil {
+		return fmt.Errorf("did not register %s", pmQueueSize, err)
+	}
+	if err := prometheus.Register(pmPercentFull); err != nil {
+		return fmt.Errorf("did not register %s", pmPercentFull, err)
+	}
+	if err := prometheus.Register(pmPercentSuccess); err != nil {
+		return fmt.Errorf("did not register %s", pmPercentSuccess, err)
+	}
+	if err := prometheus.Register(pmTasksSucceeded); err != nil {
+		return fmt.Errorf("did not register %s", pmTasksSucceeded, err)
+	}
+	if err := prometheus.Register(pmTasksFailed); err != nil {
+		return fmt.Errorf("did not register %s", pmTasksFailed, err)
+	}
+	if err := prometheus.Register(pmTaskLatency); err != nil {
+		return fmt.Errorf("did not register %s", pmTaskLatency, err)
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -86,24 +86,26 @@ func serveMetrics(metricsAddr string) {
 
 func registerMetrics() error {
 	if err := prometheus.Register(pmWorkers); err != nil {
-		return fmt.Errorf("did not register %s", pmWorkers, err)
+		return fmt.Errorf("did not register %s: %s", pmWorkers, err)
 	}
 	if err := prometheus.Register(pmQueueSize); err != nil {
-		return fmt.Errorf("did not register %s", pmQueueSize, err)
+		return fmt.Errorf("did not register %s: %s", pmQueueSize, err)
 	}
 	if err := prometheus.Register(pmPercentFull); err != nil {
-		return fmt.Errorf("did not register %s", pmPercentFull, err)
+		return fmt.Errorf("did not register %s: %s", pmPercentFull, err)
 	}
 	if err := prometheus.Register(pmPercentSuccess); err != nil {
-		return fmt.Errorf("did not register %s", pmPercentSuccess, err)
+		return fmt.Errorf("did not register %v: %s", pmPercentSuccess, err)
 	}
 	if err := prometheus.Register(pmTasksSucceeded); err != nil {
-		return fmt.Errorf("did not register %s", pmTasksSucceeded, err)
+		return fmt.Errorf("did not register %v: %s", pmTasksSucceeded, err)
 	}
 	if err := prometheus.Register(pmTasksFailed); err != nil {
-		return fmt.Errorf("did not register %s", pmTasksFailed, err)
+		return fmt.Errorf("did not register %v: %s", pmTasksFailed, err)
 	}
 	if err := prometheus.Register(pmTaskLatency); err != nil {
-		return fmt.Errorf("did not register %s", pmTaskLatency, err)
+		return fmt.Errorf("did not register %v: %s", pmTaskLatency, err)
 	}
+
+	return nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	pmWorkers        prometheus.Gauge         // number of available workers
-	pmQueueSize      prometheus.Gauge         // number of tasks in the queue awaiting handling
-	pmPercentFull    prometheus.Gauge         // the percent of the queue that is full * 100
-	pmPercentSuccess *prometheus.GaugeVec     // the percent of tasks successfully completed, labeled by task
+	pmWorkers     prometheus.Gauge // number of available workers
+	pmQueueSize   prometheus.Gauge // number of tasks in the queue awaiting handling
+	pmPercentFull prometheus.Gauge // the percent of the queue that is full * 100
+	// pmPercentSuccess *prometheus.GaugeVec     // the percent of tasks successfully completed, labeled by task
 	pmTasksSucceeded *prometheus.CounterVec   // the count of successfully completed tasks, labeled by task type
 	pmTasksFailed    *prometheus.CounterVec   // the count of failed tasks, labeled by task type
 	pmTaskLatency    *prometheus.HistogramVec // the time it is taking for tasks to complete, labeled by task type, success, and failure
@@ -47,12 +47,13 @@ func initMetrics() {
 		Help:      "the percent of the queue that is already full",
 	})
 
-	pmPercentSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: pmNamespace,
-		Subsystem: pmSubsystem,
-		Name:      "percent_success",
-		Help:      "the percent of tasks successfully completed, labeled by task",
-	}, []string{"task"})
+	// TODO: Come back to this; would need to keep track of global tasks?
+	// pmPercentSuccess = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	// 	Namespace: pmNamespace,
+	// 	Subsystem: pmSubsystem,
+	// 	Name:      "percent_success",
+	// 	Help:      "the percent of tasks successfully completed, labeled by task",
+	// }, []string{"task"})
 
 	pmTasksSucceeded = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: pmNamespace,
@@ -94,9 +95,9 @@ func registerMetrics() error {
 	if err := prometheus.Register(pmPercentFull); err != nil {
 		return fmt.Errorf("did not register %s: %s", pmPercentFull, err)
 	}
-	if err := prometheus.Register(pmPercentSuccess); err != nil {
-		return fmt.Errorf("did not register %v: %s", pmPercentSuccess, err)
-	}
+	// if err := prometheus.Register(pmPercentSuccess); err != nil {
+	// 	return fmt.Errorf("did not register %v: %s", pmPercentSuccess, err)
+	// }
 	if err := prometheus.Register(pmTasksSucceeded); err != nil {
 		return fmt.Errorf("did not register %v: %s", pmTasksSucceeded, err)
 	}

--- a/radish.go
+++ b/radish.go
@@ -322,3 +322,7 @@ func (r *Radish) Handler(task string) (handler Task, err error) {
 
 	return handler, nil
 }
+
+func init() {
+	initMetrics()
+}

--- a/worker.go
+++ b/worker.go
@@ -1,6 +1,10 @@
 package radish
 
-import "github.com/kansaslabs/x/out"
+import (
+	"time"
+
+	"github.com/kansaslabs/x/out"
+)
 
 type worker struct {
 	parent *Radish   // the parent of the worker that has the tasks queue and the handlers
@@ -14,6 +18,13 @@ taskloop:
 		case <-w.stop:
 			return
 		case task := <-w.parent.tasks:
+
+			// Update the queue size and percent full
+			pmQueueSize.Set(float64(len(w.parent.tasks)))
+			pmPercentFull.Set(float64(len(w.parent.tasks)) / float64(w.parent.config.QueueSize) * 100)
+
+			start := time.Now()
+
 			handler, err := w.parent.Handler(task.Task)
 			if err != nil {
 				// Unregistered task
@@ -26,11 +37,26 @@ taskloop:
 				// Task failure
 				out.Caution(err.Error())
 				handler.Failure(task.ID, err, task.Failure)
+
+				// Compute latency in milliseconds
+				latency := float64(time.Since(start)/1000) / 1000.0
+				pmTaskLatency.WithLabelValues(task.Task, "failed").Observe(latency)
+
+				// Update prometheus metrics with failed task
+				pmTasksFailed.WithLabelValues(task.Task).Inc()
 			} else {
 				// Task success
 				out.Debug("finished %s task %s", task.Task, task.ID)
 				handler.Success(task.ID, task.Success)
+
+				// Compute latency in milliseconds
+				latency := float64(time.Since(start)/1000) / 1000.0
+				pmTaskLatency.WithLabelValues(task.Task, "succeeded").Observe(latency)
+
+				// Update prometheus metrics with succeeded task
+				pmTasksSucceeded.WithLabelValues(task.Task).Inc()
 			}
+
 		}
 	}
 }


### PR DESCRIPTION
This PR closes #5, adding 6 new metrics to track radish task and worker progress:

- `pmWorkers`, a gauge of available workers
- `pmQueueSize`, a gauge of tasks awaiting handling
- `pmPercentFull`, a gauge indicating the percent of the queue that is full
- `pmTasksSucceeded`, a counter vector of successfully completed tasks, labeled by type
- `pmTasksFailed`, a counter vector of failed tasks, labeled by type 
- `pmTaskLatency`,   a histogram vector indicating the time for tasks to complete, labeled by task type

# TODO 
An additional metric, `pmPercentSuccess`, a gauge vector of the percent of tasks successfully completed, has been left as a follow-on task since I couldn't think of an elegant way to do it (assuming this metric would track the success rate globally, it will require us to maintain that state somehow across a long-running program)