### PR TITLE
Turnip Dockerfile and example docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Docker
+.docker

--- a/cmd/turnip/main.go
+++ b/cmd/turnip/main.go
@@ -49,6 +49,12 @@ func main() {
 					Value:  ":5356",
 					EnvVar: "TURNIP_ADDR",
 				},
+				cli.StringFlag{
+					Name:   "m, metrics-addr",
+					Usage:  "the address to serve prometheus metrics on",
+					Value:  ":9090",
+					EnvVar: "TURNIP_METRICS_ADDR",
+				},
 				cli.IntFlag{
 					Name:   "w, workers",
 					Usage:  "number of workers to start with (default is num cpus)",
@@ -72,6 +78,11 @@ func main() {
 					Value:  50,
 					EnvVar: "TURNIP_CAUTION_THRESHOLD",
 				},
+				cli.BoolFlag{
+					Name:   "S, no-metrics",
+					Usage:  "do not run the prometheus metrics server",
+					EnvVar: "TURNIP_SUPPRESS_METRICS",
+				},
 			},
 		},
 	}
@@ -86,6 +97,8 @@ func serve(c *cli.Context) (err error) {
 		QueueSize:        c.Int("queue-size"),
 		Workers:          c.Int("workers"),
 		Addr:             c.String("addr"),
+		MetricsAddr:      c.String("metrics-addr"),
+		SuppressMetrics:  c.Bool("no-metrics"),
 		LogLevel:         c.String("log-level"),
 		CautionThreshold: c.Uint("caution-threshold"),
 	}

--- a/config.go
+++ b/config.go
@@ -19,8 +19,9 @@ var logLevels = map[string]uint8{
 }
 
 const (
-	defaultQueueSize = 5000
-	defaultAddr      = ":5356"
+	defaultQueueSize   = 5000
+	defaultAddr        = ":5356"
+	defaultMetricsAddr = ":9090"
 )
 
 // Config allows you to specify runtime options to the Radish server and job queue.
@@ -28,6 +29,8 @@ type Config struct {
 	QueueSize        int    // specifies the size of the tasks channel, delay requests will block if the queue is full (default 5000, cannot be 0)
 	Workers          int    // the number of workers to start radish with (default is num cpus)
 	Addr             string // server address to listen on (default :5356)
+	MetricsAddr      string // address to serve prometheus metrics on (default :9090)
+	SuppressMetrics  bool   // do not register or serve prometheus metrics (default false)
 	LogLevel         string // the level to log at (default is info)
 	CautionThreshold uint   // the number of messages accumulated before issuing another caution
 }
@@ -47,6 +50,11 @@ func (c *Config) Validate() (err error) {
 	// Handle the addr
 	if c.Addr == "" {
 		c.Addr = defaultAddr
+	}
+
+	// Handle the metrics addr
+	if c.MetricsAddr == "" {
+		c.MetricsAddr = defaultMetricsAddr
 	}
 
 	// Handle the log level

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.14 AS builder
+
+# This assumes that you're building the docker file from the root of the radish repo:
+# docker build -t kansaslabs/turnip:latest -f examples/Dockerfile .
+WORKDIR /go/src/github.com/kansaslabs/radish/
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o turnip ./cmd/turnip/
+
+FROM alpine:latest
+
+LABEL maintainer="Kansas Labs <kansaslabs@gmail.com>"
+LABEL description="Turnip is a demo/benchmark implementation of a radish task queue service."
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/kansaslabs/radish/turnip .
+
+ENTRYPOINT [ "./turnip", "serve" ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,70 @@
+# Getting Started
+
+The `examples` folder contains `turnip`, an example of a service that implements the radish API to illustrate how to use radish for concurrent task monitoring inside the context of a real application. Using `turnip` as a demo, you can experiment with adding different types of tasks, scaling up and down the number of concurrent workers, and visualizing the resulting prometheus metrics.
+
+## Running the container
+
+After installing [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop), run docker from inside the `examples` directory:
+
+    ```bash
+    $ docker-compose up
+    ```
+
+You'll now be running three services:
+- Turnip: a demo of using the radish API implemented in the `turnip` directory, which is serving metrics on port 9090.
+- Prometheus: configured by the `prometheus.yml` file, which will scrape for prometheus metrics every second.
+- Grafana: a time series visualization and monitoring UI that will scrape Prometheus every second and allow us to visualize our metrics.
+
+
+## Interacting with the Radish API
+With the Turnip server running, you'll now be able to interact with the radish API,
+
+e.g. to see what kind of task types are available:
+
+```bash
+$ radish status
+```
+
+Or to queue up short tasks:
+```bash
+$ radish -U queue -t short
+```
+
+Long tasks:
+```bash
+$ radish -U queue -t long
+```
+
+Or tasks that have a high probability of failure:
+```bash
+$ radish -U queue -t chance
+```
+
+Or to scale up or scale down the number of concurrent workers to handle those tasks:
+```bash
+$ radish -U scale -w 5
+```
+
+Running commands such as those above will generate updates to the prometheus metrics, which will be visible in the Grafana dashboard, once you've configured it...
+
+## Configuring the dashboard
+
+In the browser navigate to Grafana, which is at [`http://localhost:3000`](http://localhost:3000) and sign in with the default login and password, both of which are "admin". You'll be prompted to update your password.
+
+Next create a data source; select the Prometheus option; under the `HTTP` header, change the URL to `http://prometheus:9090` and set the HTTP method to `GET`; save and test.
+
+Next navigate back to the main Grafana page to build a dashboard. Choose `Add Query`, under `Metrics`, try adding a sample metric, such as a sum of the workers in the queue, `scalar(radish_queue_workers)`. Metrics will be named `radish_queue_metric_name` i.e. the namespace_subsystem_metric and then labels can be accessed with a `.` property.
+
+## Create a simulation
+
+There won't be too much going on in the dashboard unless we are running commands that actively change the numbers of tasks and workers. Here's a simple simulation you can run in order to generate some activity:
+
+```bash
+#!/bin/bash
+while true; do
+    radish -U queue -t chance || break
+    sleep .1
+    radish -U queue -t long || break
+    sleep .2
+done
+```

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  turnip:
+    image: kansaslabs/turnip:latest
+    ports:
+    - 5356:5356
+    - 9090:9090
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+    - 8080:8080
+    volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+    - 3000:3000
+    volumes:
+    - ./.docker/grafana:/var/lib/grafana

--- a/examples/prometheus.yml
+++ b/examples/prometheus.yml
@@ -1,0 +1,6 @@
+# An example Prometheus configuration to scrape a single endpoint from docker-compose
+scrape_configs:
+  - job_name: 'radish'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['docker.for.mac.localhost:9090']

--- a/examples/prometheus.yml
+++ b/examples/prometheus.yml
@@ -3,4 +3,4 @@ scrape_configs:
   - job_name: 'radish'
     scrape_interval: 1s
     static_configs:
-      - targets: ['docker.for.mac.localhost:9090']
+      - targets: ['turnip:9090']

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,15 @@ require (
 	github.com/golang/protobuf v1.4.0
 	github.com/joho/godotenv v1.3.0
 	github.com/kansaslabs/x v0.2.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli v1.22.4
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/grpc v1.29.1
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/radish.go
+++ b/radish.go
@@ -128,7 +128,7 @@ import (
 	"github.com/pborman/uuid"
 )
 
-// PackageVersion of the current Raft implementation
+// PackageVersion of the current Radish implementation
 const PackageVersion = "1.0"
 
 // New creates a Radish object with the specified config and registers the specified

--- a/serve.go
+++ b/serve.go
@@ -12,6 +12,13 @@ import (
 
 // Listen on the configured address and port for API requests and run prometheus metrics server.
 func (r *Radish) Listen() (err error) {
+	if !r.config.SuppressMetrics {
+		if err = registerMetrics(); err != nil {
+			return fmt.Errorf("could not register prometheus metrics: %s", err)
+		}
+		go serveMetrics(r.config.MetricsAddr)
+	}
+
 	// Open TCP socket to listen on from the configuration
 	var sock net.Listener
 	if sock, err = net.Listen("tcp", r.config.Addr); err != nil {


### PR DESCRIPTION
Adds Docker file for turnip and example docker-compose and Prometheus configuration.

Updates the server config with metrics address and a bool to turn of metrics if needed. Serve now registers the metrics and serves them to prometheus.

TODO:

- [x] configure grafana 
- [x] write example documentation

Fixes #6