### PR TITLE
Task Status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module go.rtnl.ai/radish
 
 go 1.25.6
 
-require go.rtnl.ai/x v1.10.0
+require (
+	github.com/stretchr/testify v1.11.1
+	go.rtnl.ai/x v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.rtnl.ai/x v1.10.0 h1:NaFXZkhLlAFygevskDwWYMlu2zF3U29j2cmEcAcfJl4=
 go.rtnl.ai/x v1.10.0/go.mod h1:ciQ9PaXDtZDznzBrGDBV2yTElKX3aJgtQfi6V8613bo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/status/status.go
+++ b/status/status.go
@@ -1,0 +1,118 @@
+package status
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Status uint8
+
+const (
+	StatusUnknown Status = iota
+	StatusPending
+	StatusRunning
+	StatusSuccess
+	StatusFailure
+	StatusRetry
+	StatusRevoked
+	StatusScheduled
+
+	// The terminator is used to determine the last value of the enum.
+	statusTerminator
+)
+
+var statusNames = [8]string{
+	"unknown",
+	"pending",
+	"running",
+	"success",
+	"failure",
+	"retry",
+	"revoked",
+	"scheduled",
+}
+
+func Parse(s any) (Status, error) {
+	switch v := s.(type) {
+	case string:
+		s = strings.TrimSpace(strings.ToLower(v))
+		if s == "" {
+			return StatusUnknown, nil
+		}
+
+		for i, name := range statusNames {
+			if name == s {
+				return Status(i), nil
+			}
+		}
+
+		return StatusUnknown, fmt.Errorf("invalid status: %q", s)
+	case float64:
+		if v < 0 || v > float64(^uint8(0)) || v != float64(uint8(v)) {
+			return StatusUnknown, fmt.Errorf("cannot parse %v to Status", v)
+		}
+		return Status(uint8(v)), nil
+	case uint8:
+		return Status(v), nil
+	case Status:
+		return v, nil
+	default:
+		return StatusUnknown, fmt.Errorf("cannot parse %T to Status", s)
+	}
+}
+
+func (s Status) String() string {
+	if s >= statusTerminator {
+		return statusNames[0]
+	}
+	return statusNames[s]
+}
+
+func (s Status) Uint8() uint8 {
+	return uint8(s)
+}
+
+//============================================================================
+// JSON Serialization and Deserialization
+//============================================================================
+
+func (s Status) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *Status) UnmarshalJSON(data []byte) (err error) {
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	if *s, err = Parse(v); err != nil {
+		return err
+	}
+	return nil
+}
+
+//===========================================================================
+// Database Interaction
+//===========================================================================
+
+func (s *Status) Scan(src interface{}) (err error) {
+	switch x := src.(type) {
+	case nil:
+		return nil
+	case string:
+		*s, err = Parse(x)
+		return err
+	case []byte:
+		*s, err = Parse(string(x))
+		return err
+	default:
+		return fmt.Errorf("cannot scan %T into a status", src)
+	}
+}
+
+func (s Status) Value() (driver.Value, error) {
+	return s.String(), nil
+}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -1,0 +1,168 @@
+package status_test
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish/status"
+)
+
+var (
+	defaultInvalid = []any{"foo", "123", "INVALID", 257, -1, 3.14, struct{}{}, true, false}
+	statusValues   = []status.Status{
+		status.StatusUnknown,
+		status.StatusPending,
+		status.StatusRunning,
+		status.StatusSuccess,
+		status.StatusFailure,
+		status.StatusRetry,
+		status.StatusRevoked,
+		status.StatusScheduled,
+	}
+	statusStrings = []string{
+		"unknown",
+		"pending",
+		"running",
+		"success",
+		"failure",
+		"retry",
+		"revoked",
+		"scheduled",
+	}
+)
+
+const (
+	dbVarcharLimit = 16
+)
+
+func TestString(t *testing.T) {
+	for i, enum := range statusValues {
+		require.Equal(t, statusStrings[i], enum.String(), "expected status to have string representation %q, got %q", statusStrings[i], enum.String())
+	}
+
+	// Test Zero Values
+	zero := status.Status(0)
+	require.Equal(t, status.StatusUnknown.String(), zero.String(), "expected status to have string representation \"unknown\" for zero value")
+
+	empty, err := status.Parse("")
+	require.NoError(t, err, "failed to parse empty string for status")
+	require.Equal(t, status.StatusUnknown.String(), empty.String(), "expected status to have string representation \"unknown\" for empty string not %q", empty.String())
+}
+
+func TestStringBounds(t *testing.T) {
+	max := uint8(0)
+	min := uint8(255)
+
+	for i := range statusValues {
+		if uint8(i) > max {
+			max = uint8(i)
+		}
+		if uint8(i) < min {
+			min = uint8(i)
+		}
+	}
+
+	above := status.Status(max + 1)
+	require.Equal(t, status.StatusUnknown.String(), above.String(), "expected status to have string representation \"unknown\" for unknown value")
+
+	// Test zero value
+	if min > 0 {
+		zero := status.Status(0)
+		require.Equal(t, status.StatusUnknown.String(), zero.String(), "expected status to have string representation \"unknown\" for zero value")
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		makeTestCases := func(i int, enum status.Status) []any {
+			tests := make([]any, 0, 8)
+			tests = append(tests, statusStrings[i])
+			tests = append(tests, enum.Uint8())
+			tests = append(tests, float64(enum.Uint8()))
+			tests = append(tests, enum)
+			tests = append(tests, strings.ToUpper(statusStrings[i]), strings.ToLower(statusStrings[i]))
+			tests = append(tests, mixedCase(statusStrings[i]))
+
+			return tests
+		}
+
+		for i, enum := range statusValues {
+			tests := makeTestCases(i, enum)
+			for _, input := range tests {
+				actual, err := status.Parse(input)
+				require.NoError(t, err, "failed to parse valid status value %#v", input)
+				require.Equal(t, enum, actual, "expected parsing valid status value %#v", input)
+			}
+		}
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		for _, str := range defaultInvalid {
+			actual, err := status.Parse(str)
+			require.Error(t, err, "expected parsing invalid status value %q to error", str)
+			require.Equal(t, uint8(0), actual.Uint8(), "expected parsing invalid status value %q to return zero value, got %d", str, actual.Uint8())
+		}
+	})
+}
+
+func TestJSON(t *testing.T) {
+	t.Run("Serialization", func(t *testing.T) {
+		for _, enum := range statusValues {
+			orig := status.Status(enum.Uint8())
+			data, err := json.Marshal(orig)
+			require.NoError(t, err, "failed to marshal status value %q", orig.String())
+
+			cmp := status.Status(0)
+			err = json.Unmarshal(data, &cmp)
+			require.NoError(t, err, "failed to unmarshal status value %q", orig.String())
+			require.Equal(t, orig, cmp, "unmarshaled status does not match original")
+		}
+	})
+
+	t.Run("Errors", func(t *testing.T) {
+		inputs := make([][]byte, 0, len(defaultInvalid)+2)
+		inputs = append(inputs, []byte(`"unquoted`), []byte(`{"missing":}`)) // add bad JSON inputs
+
+		// Add parse errors
+		for _, v := range defaultInvalid {
+			if data, err := json.Marshal(v); err == nil {
+				inputs = append(inputs, data)
+			}
+		}
+
+		for _, data := range inputs {
+			cmp := status.Status(0)
+			err := json.Unmarshal(data, &cmp)
+			require.Error(t, err, "expected unmarshaling invalid status JSON value %q to error", string(data))
+			require.Equal(t, uint8(0), cmp.Uint8(), "expected unmarshaling invalid status JSON value %q to return zero value, got %d", string(data), cmp.Uint8())
+		}
+	})
+}
+
+func TestDatabase(t *testing.T) {
+	// TODO: implement scan and value tests
+	t.Run("VARCHAR", func(t *testing.T) {
+		// Ensure that all string representations are less than or equal to the db VARCHAR limit
+		for _, enum := range statusValues {
+			require.LessOrEqual(t, len(enum.String()), dbVarcharLimit, "expected status value %q to be less than or equal to %d characters", enum.String(), dbVarcharLimit)
+		}
+	})
+}
+
+func mixedCase(s string) string {
+	b := make([]rune, len(s))
+	for i, r := range s {
+		// Flip a coin and make the character upper or lower case
+		if rand.Intn(2) == 0 {
+			r = unicode.ToLower(r)
+		} else {
+			r = unicode.ToUpper(r)
+		}
+		b[i] = r
+	}
+	return string(b)
+}


### PR DESCRIPTION
### Scope of changes

Adds the Task Status enum to the library.

### Estimated PR Size:

- [x] Tiny
- [ ] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is an additive new `status` package plus unit tests and a test-only dependency (`testify`), with no changes to existing runtime behavior elsewhere.
> 
> **Overview**
> Adds a new `status.Status` enum for task lifecycle states (e.g. `pending`, `running`, `success`, etc.) including `Parse` helpers, string conversion, JSON marshal/unmarshal, and `database/sql` `Scan`/`Value` support.
> 
> Introduces unit tests covering parsing and JSON round-trips, and updates `go.mod`/`go.sum` to include `github.com/stretchr/testify` (and indirect deps) for testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f5dbdd8072a94040e7a6f6d408e0df56efb9b9e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->