### PR TITLE
Primary Task API Interfaces

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,3 @@
+package radish
+
+type Config struct{}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,1 @@
+package radish_test

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.6
 
 require (
 	github.com/stretchr/testify v1.11.1
+	go.rtnl.ai/ulid v1.2.0
 	go.rtnl.ai/x v1.10.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.rtnl.ai/ulid v1.2.0 h1:EwIst7WZVdCmbtbDmIrRB15q03Qe9hmHHbxNej0V/wI=
+go.rtnl.ai/ulid v1.2.0/go.mod h1:F95yPYwEEZdz5sM4GC6buziff6xD+7XVcGZ/8n37Cn0=
 go.rtnl.ai/x v1.10.0 h1:NaFXZkhLlAFygevskDwWYMlu2zF3U29j2cmEcAcfJl4=
 go.rtnl.ai/x v1.10.0/go.mod h1:ciQ9PaXDtZDznzBrGDBV2yTElKX3aJgtQfi6V8613bo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/worker/iface.go
+++ b/internal/worker/iface.go
@@ -1,0 +1,25 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"go.rtnl.ai/radish/models"
+)
+
+type Worker interface {
+	Retry() *Retry
+	Timeout() time.Duration
+	UnmarshalTask() error
+	Do(ctx context.Context) error
+}
+
+type Factory interface {
+	Make(task *models.TaskMeta) (Worker, error)
+}
+
+// An internal clone of the Retry struct from the radish package for type indirection.
+type Retry struct {
+	Retry bool
+	Delay time.Duration
+}

--- a/models/errors.go
+++ b/models/errors.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type AttemptErrors []AttemptError
+
+// An error from a single task attempt that failed due to error or panic.
+type AttemptError struct {
+	// The attempt number on which the error occurred.
+	Attempt int `json:"attempt"`
+
+	// The error that occurred.
+	Error string `json:"error"`
+
+	// Trace contains a stack trace from a job that panicked.
+	// In the case of a non-panic or error produced as a stuck task, this value will
+	// be an empty string
+	Trace string `json:"trace"`
+
+	// Timestamp that the error occurred
+	Timestamp time.Time `json:"timestamp"`
+}
+
+//===========================================================================
+// Database Interaction
+//===========================================================================
+
+func (s *AttemptErrors) Scan(src interface{}) (err error) {
+	switch x := src.(type) {
+	case nil:
+		*s = make(AttemptErrors, 0)
+		return nil
+	case []byte:
+		buf := make([]byte, len(x))
+		copy(buf, x)
+		return json.Unmarshal(buf, s)
+	default:
+		return fmt.Errorf("cannot scan %T into attempt errors", src)
+	}
+}
+
+func (s AttemptErrors) Value() (driver.Value, error) {
+	return json.Marshal(s)
+}

--- a/models/task.go
+++ b/models/task.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"database/sql"
+	"time"
+
+	"go.rtnl.ai/radish/status"
+	"go.rtnl.ai/ulid"
+)
+
+// TaskMeta is the properties of a task that are persisted in the database.
+type TaskMeta struct {
+	// ID of the task. A ULID that guarantees montonically increasing values.
+	ID ulid.ULID
+
+	// Current attempt of the task. Attempts are inserted at 0, the number is
+	// incremented to 1 the first time it is worked, and it may be incremented further
+	// if it errors.
+	Attempt int
+
+	// Set of client IDs that have worked this job.
+	AttemptedBy []string
+
+	// Errors for each attempt that failed, ordered from earliest to latest.
+	Errors AttemptErrors
+
+	// Timestamp of when the task was completed successfully or failed.
+	Finished sql.NullTime
+
+	// Kind uniquely identifies the type of task and which worker is responsible for processing it.
+	Kind string
+
+	// Timestamp of when the last attempt to work the task was started.
+	LastAttempt sql.NullTime
+
+	// JSON encoded payload of the task.
+	Payload []byte
+
+	// The maximum number of attempts the task will be tried before it errors for the
+	// last time and will no longer be attempted.
+	Retries int
+
+	// Status of the task.
+	Status status.Status
+
+	// Timestamp of when the task becomes visible to workers. This is used both for
+	// backoff delays in retries and for scheduling tasks in the future.
+	VisibleAt sql.NullTime
+
+	// Timestamp Metadata
+	Created  time.Time
+	Modified time.Time
+}

--- a/radish.go
+++ b/radish.go
@@ -1,1 +1,8 @@
 package radish
+
+type Radish struct {
+}
+
+func New() (*Radish, error) {
+	return &Radish{}, nil
+}

--- a/radish_test.go
+++ b/radish_test.go
@@ -1,13 +1,1 @@
 package radish_test
-
-import (
-	"testing"
-
-	"go.rtnl.ai/radish"
-	"go.rtnl.ai/x/assert"
-)
-
-func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.1.0", radish.Version(true))
-	assert.Equal(t, "0.1.0-alpha.1", radish.Version(false))
-}

--- a/task.go
+++ b/task.go
@@ -1,0 +1,35 @@
+package radish
+
+import "go.rtnl.ai/radish/models"
+
+// Task is an interface that represents the arguments for the execution of a specifc
+// task of type T that is processed by a worker that also implements type T. This
+// data structure is serialized to JSON and sent to the broker for processing.
+//
+// The struct is serialized using `encoding/json` and respects json struct tags.
+type Task interface {
+	// Kind returns the unique identifier for the task type. This is used to route the
+	// task to the appropriate worker. We use strings rather than type names to allow
+	// application specific definitions and renaming of task types.
+	//
+	// Kinds should be formatted without spaces and generally lowercase. Avoid using
+	// special characters and use only alphanumeric characters.
+	//
+	// After deploying tasks, it is not safe to rename the kind (unless the queue has
+	// been cleared of all existing tasks). Renaming safely can be accomplished using
+	// the `TaskWithAliases` interface.
+	Kind() string
+}
+
+// TaskWithAliases is an interface that allows for the definition of aliases for a task
+// kind. This is useful for renaming tasks after deployment without losing existing tasks.
+type TaskWithAliases interface {
+	// Kinds that the associated task worker will respond to.
+	KindAliases() []string
+}
+
+type TaskInfo[T Task] struct {
+	*models.TaskMeta
+
+	Task T
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,68 @@
+package radish_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish"
+)
+
+//============================================================================
+// Test Tasks
+//============================================================================
+
+type SleepTask struct {
+	Duration time.Duration `json:"duration"`
+}
+
+func (t *SleepTask) Kind() string {
+	return "sleep"
+}
+
+type SortTask struct {
+	Numbers []int `json:"numbers"`
+}
+
+func (t *SortTask) Kind() string {
+	return "sort"
+}
+
+func (t *SortTask) KindAliases() []string {
+	return []string{"sort-numbers", "sort-integers"}
+}
+
+type RandomFailureTask struct {
+	Probability float64 `json:"probability"`
+}
+
+func (t *RandomFailureTask) Kind() string {
+	return "failchance"
+}
+
+func (t *RandomFailureTask) KindAliases() []string {
+	return []string{"random-failure", "random-error"}
+}
+
+type MockTask struct{}
+
+func (t *MockTask) Kind() string {
+	return "mock"
+}
+
+func (t *MockTask) KindAliases() []string {
+	// intentionally duplicates the SortTask kind aliases
+	return []string{"sleep", "sort", "failchance"}
+}
+
+//============================================================================
+// Interface Implementations
+//============================================================================
+
+func TestTaskInterface(t *testing.T) {
+	require.Implements(t, (*radish.Task)(nil), new(SleepTask))
+	require.NotImplements(t, (*radish.TaskWithAliases)(nil), new(SleepTask))
+	require.Implements(t, (*radish.TaskWithAliases)(nil), new(SortTask))
+	require.Implements(t, (*radish.Task)(nil), new(RandomFailureTask))
+	require.Implements(t, (*radish.TaskWithAliases)(nil), new(RandomFailureTask))
+}

--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,141 @@
+package radish
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.rtnl.ai/radish/internal/worker"
+)
+
+//============================================================================
+// Worker Interface
+//============================================================================
+
+// All workers must implement the Worker interface and follow the concurrency
+// guidelines in order to process tasks of the given type.
+type Worker[T Task] interface {
+	// By implementing this interface, the worker is able to determine if the task
+	// should be retried for the given task info, and how long to delay before the
+	// next retry. If nil is returned as the retry, the default retry policy is used.
+	Retry(*TaskInfo[T]) *Retry
+
+	// By implementing this interface, the worker is able to determine the timeout for the
+	// given task. If 0 is returned as the timeout, the default timeout policy is used.
+	Timeout(*TaskInfo[T]) time.Duration
+
+	// Do performs the work for for the given task and returns an error if the task
+	// fails. The context will be configured with a timeout according to the worker
+	// settings and may be cancelled for other reasons.
+	//
+	// If no error is returned, the job is assumed to have succeeded and will be marked
+	// as completed. Any error returned will be part of the task info saved in the backend.
+	//
+	// Note that the Do method is expected to be thread-safe and may be called
+	// concurrently by multiple workers. Depending on the global concurrency settings.
+	Do(context.Context, *TaskInfo[T]) error
+}
+
+// Indicates if the task should be retried and the delay before the next retry. If no
+// delay is provided, the default delay will be used.
+type Retry struct {
+	Retry bool
+	Delay time.Duration
+}
+
+//============================================================================
+// Worker Defaults for Embedding
+//============================================================================
+
+// Embed this struct in a worker that only implements the Do method to provide the
+// default retry and timeout policies.
+type WorkerDefaults[T Task] struct{}
+
+func (w *WorkerDefaults[T]) Retry(*TaskInfo[T]) *Retry { return nil }
+
+func (w *WorkerDefaults[T]) Timeout(*TaskInfo[T]) time.Duration { return 0 }
+
+//============================================================================
+// Workers as functions (for quick worker definitions)
+//============================================================================
+
+// Wrap a function to implement the Worker interface. A Task is required to specify
+// the kind of task that the function will process.
+func WorkFunc[T Task](do func(context.Context, *TaskInfo[T]) error) Worker[T] {
+	return &workFunc[T]{
+		kind: (*new(T)).Kind(),
+		do:   do,
+	}
+}
+
+// Function wrapper that implements the Worker interface.
+type workFunc[T Task] struct {
+	WorkerDefaults[T]
+
+	kind string
+	do   func(context.Context, *TaskInfo[T]) error
+}
+
+func (wf *workFunc[T]) Do(ctx context.Context, task *TaskInfo[T]) error {
+	return wf.do(ctx, task)
+}
+
+//============================================================================
+// Workers Registration and Wrapper
+//============================================================================
+
+func AddWorker[T Task](w *Workers, worker Worker[T]) {
+	if err := AddWorkerSafe(w, worker); err != nil {
+		panic(err)
+	}
+}
+
+func AddWorkerSafe[T Task](w *Workers, worker Worker[T]) error {
+	var task T
+	return w.add(task, &workerFactory[T]{worker: worker})
+}
+
+// Workers is a list of available job workers. A worker must be registered for each
+// type of task that can be handled by the radish instance.
+type Workers struct {
+	workers map[string]untypedWorker
+}
+
+type untypedWorker struct {
+	task    Task
+	factory worker.Factory
+}
+
+func (w *Workers) add(task Task, factory worker.Factory) error {
+	checkRegistered := func(kind string) error {
+		if _, ok := w.workers[kind]; ok {
+			return fmt.Errorf("task %q is already registered", kind)
+		}
+		return nil
+	}
+
+	if w.workers == nil {
+		w.workers = make(map[string]untypedWorker)
+	}
+
+	kind := task.Kind()
+	if err := checkRegistered(kind); err != nil {
+		return err
+	}
+
+	w.workers[kind] = untypedWorker{
+		task:    task,
+		factory: factory,
+	}
+
+	if aliases, ok := task.(TaskWithAliases); ok {
+		for _, alias := range aliases.KindAliases() {
+			if err := checkRegistered(alias); err != nil {
+				return err
+			}
+			w.workers[alias] = w.workers[kind]
+		}
+	}
+
+	return nil
+}

--- a/worker.go
+++ b/worker.go
@@ -139,3 +139,12 @@ func (w *Workers) add(task Task, factory worker.Factory) error {
 
 	return nil
 }
+
+func (w *Workers) Has(kind string) bool {
+	_, ok := w.workers[kind]
+	return ok
+}
+
+func (w *Workers) Len() int {
+	return len(w.workers)
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,128 @@
+package radish_test
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish"
+)
+
+//============================================================================
+// Test Workers
+//============================================================================
+
+type SleepWorker struct {
+	radish.WorkerDefaults[*SleepTask]
+}
+
+func (w *SleepWorker) Do(ctx context.Context, task *radish.TaskInfo[*SleepTask]) error {
+	time.Sleep(task.Task.Duration)
+	return nil
+}
+
+type SortWorker struct {
+	radish.WorkerDefaults[*SortTask]
+}
+
+func (w *SortWorker) Do(ctx context.Context, task *radish.TaskInfo[*SortTask]) error {
+	sort.Ints(task.Task.Numbers)
+	return nil
+}
+
+type RandomFailureWorker struct {
+	radish.WorkerDefaults[*RandomFailureTask]
+}
+
+func (w *RandomFailureWorker) Do(ctx context.Context, task *radish.TaskInfo[*RandomFailureTask]) error {
+	if rand.Float64() < task.Task.Probability {
+		return errors.New("random failure")
+	}
+	return nil
+}
+
+type MockWorker struct {
+	radish.WorkerDefaults[*MockTask]
+	OnDo func(ctx context.Context, task *radish.TaskInfo[*MockTask]) error
+}
+
+func (w *MockWorker) Do(ctx context.Context, task *radish.TaskInfo[*MockTask]) error {
+	if w.OnDo != nil {
+		return w.OnDo(ctx, task)
+	}
+	return nil
+}
+
+//============================================================================
+// Interface Implementations
+//============================================================================
+
+func TestWorkerInterface(t *testing.T) {
+	require.Implements(t, (*radish.Worker[*SleepTask])(nil), new(SleepWorker))
+	require.Implements(t, (*radish.Worker[*SortTask])(nil), new(SortWorker))
+	require.Implements(t, (*radish.Worker[*RandomFailureTask])(nil), new(RandomFailureWorker))
+}
+
+func TestWorkFunc(t *testing.T) {
+	worker := radish.WorkFunc(func(ctx context.Context, task *radish.TaskInfo[*SortTask]) error {
+		sort.Ints(task.Task.Numbers)
+		return nil
+	})
+	require.Implements(t, (*radish.Worker[*SortTask])(nil), worker)
+	require.NotImplements(t, (*radish.Worker[*SleepTask])(nil), worker)
+
+	info := &radish.TaskInfo[*SortTask]{
+		Task: &SortTask{
+			Numbers: []int{3, 1, 2},
+		},
+	}
+	require.NoError(t, worker.Do(context.Background(), info))
+	require.Equal(t, []int{1, 2, 3}, info.Task.Numbers)
+}
+
+//============================================================================
+// Workers Tests
+//============================================================================
+
+func TestWorkers(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		workers := &radish.Workers{}
+		radish.AddWorker(workers, new(SleepWorker))
+		radish.AddWorker(workers, new(SortWorker))
+		radish.AddWorker(workers, new(RandomFailureWorker))
+
+		require.Equal(t, 7, workers.Len())
+		require.True(t, workers.Has("sleep"))
+		require.True(t, workers.Has("sort"))
+		require.True(t, workers.Has("sort-numbers"))
+		require.True(t, workers.Has("sort-integers"))
+		require.True(t, workers.Has("failchance"))
+		require.True(t, workers.Has("random-failure"))
+		require.True(t, workers.Has("random-error"))
+		require.False(t, workers.Has("unknown"))
+	})
+
+	t.Run("Duplicate", func(t *testing.T) {
+		workers := &radish.Workers{}
+		radish.AddWorker(workers, new(SleepWorker))
+		require.Error(t, radish.AddWorkerSafe(workers, new(SleepWorker)))
+	})
+
+	t.Run("DuplicateAlias", func(t *testing.T) {
+		workers := &radish.Workers{}
+		radish.AddWorker(workers, new(SortWorker))
+		require.Error(t, radish.AddWorkerSafe(workers, new(MockWorker)))
+	})
+
+	t.Run("DuplicatePanics", func(t *testing.T) {
+		workers := &radish.Workers{}
+		radish.AddWorker(workers, new(SortWorker))
+		require.Panics(t, func() {
+			radish.AddWorker(workers, new(SortWorker))
+		})
+	})
+}

--- a/wrapper.go
+++ b/wrapper.go
@@ -1,0 +1,59 @@
+package radish
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.rtnl.ai/radish/internal/worker"
+	"go.rtnl.ai/radish/models"
+)
+
+// The worker factory implements the worker.Factory interface to create a wrapped worker.
+// This converts the generic Worker[T] interface to the worker.Worker interface.
+type workerFactory[T Task] struct {
+	worker Worker[T]
+}
+
+// The wrapped worker implements the worker.Worker interface to perform the actual work.
+// This converts the generic Worker[T] interface to the worker.Worker interface.
+type wrappedWorker[T Task] struct {
+	task   *TaskInfo[T]
+	meta   *models.TaskMeta
+	worker Worker[T]
+}
+
+// The worker factory creates a wrapped worker for the given task.
+func (f *workerFactory[T]) Make(task *models.TaskMeta) (worker.Worker, error) {
+	return &wrappedWorker[T]{
+		meta:   task,
+		worker: f.worker,
+	}, nil
+}
+
+// Retry passes through to the typed underlying worker.
+func (w *wrappedWorker[T]) Retry() *worker.Retry {
+	if retry := w.worker.Retry(w.task); retry != nil {
+		return &worker.Retry{Retry: retry.Retry, Delay: retry.Delay}
+	}
+	return nil
+}
+
+// Timeout passes through to the typed underlying worker.
+func (w *wrappedWorker[T]) Timeout() time.Duration {
+	return w.worker.Timeout(w.task)
+}
+
+// Create the typed task info then unmarshal the task payload into the task.
+// This must be called before the Do method otherwise the task will be nil.
+func (w *wrappedWorker[T]) UnmarshalTask() error {
+	w.task = &TaskInfo[T]{
+		TaskMeta: w.meta,
+	}
+	return json.Unmarshal(w.meta.Payload, &w.task.Task)
+}
+
+// Do passes through to the typed underlying worker.
+func (w *wrappedWorker[T]) Do(ctx context.Context) error {
+	return w.worker.Do(ctx, w.task)
+}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -3,6 +3,7 @@ package radish
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -28,7 +29,7 @@ type RandomWorker struct {
 
 func (w *RandomWorker) Do(ctx context.Context, task *TaskInfo[*RandomTask]) error {
 	time.Sleep(task.Task.Sleep)
-	task.Task.Value = rand.Intn(100)
+	task.Task.Value = rand.Intn(math.MaxInt)
 	return nil
 }
 

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -1,0 +1,85 @@
+package radish
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish/internal/worker"
+	"go.rtnl.ai/radish/models"
+)
+
+type RandomTask struct {
+	Sleep time.Duration `json:"sleep"`
+	Value int           `json:"value"`
+}
+
+func (t *RandomTask) Kind() string {
+	return "random"
+}
+
+type RandomWorker struct {
+	WorkerDefaults[*RandomTask]
+}
+
+func (w *RandomWorker) Do(ctx context.Context, task *TaskInfo[*RandomTask]) error {
+	time.Sleep(task.Task.Sleep)
+	task.Task.Value = rand.Intn(100)
+	return nil
+}
+
+func TestFactory(t *testing.T) {
+	workers := &Workers{}
+	AddWorker(workers, new(RandomWorker))
+
+	// Simulate making a bunch of tasks with the factory
+	tasks := make([]worker.Worker, 16)
+	for i := range tasks {
+		var err error
+		tasks[i], err = workers.workers["random"].factory.Make(&models.TaskMeta{
+			Kind:    "random",
+			Payload: []byte(fmt.Sprintf(`{"sleep": %d, "value": 0}`, randomSleep())),
+		})
+		require.NoError(t, err)
+	}
+
+	// Execute all the tasks
+	var wg sync.WaitGroup
+	for _, task := range tasks {
+		wg.Add(1)
+		go func(task worker.Worker) {
+			defer wg.Done()
+			require.NoError(t, task.UnmarshalTask())
+			require.NoError(t, task.Do(context.Background()))
+		}(task)
+	}
+
+	wg.Wait()
+
+	// Check the results
+	for i, task := range tasks {
+		require.Nil(t, task.Retry())
+		require.Zero(t, task.Timeout())
+
+		for j, other := range tasks {
+			if i == j {
+				continue
+			}
+
+			wtask := task.(*wrappedWorker[*RandomTask])
+			otask := other.(*wrappedWorker[*RandomTask])
+
+			require.NotEqual(t, wtask.task.Task, otask.task.Task)
+			require.NotEqual(t, wtask.task.Task.Value, otask.task.Task.Value)
+		}
+	}
+
+}
+
+func randomSleep() time.Duration {
+	return time.Duration(rand.Intn(2000)+500) * time.Millisecond
+}


### PR DESCRIPTION
### Scope of changes

Implements the primary radish interfaces.

### Estimated PR Size:

- [ ] Tiny
- [x] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces foundational types and registration/wrapping logic that will underpin task execution; bugs here could affect worker routing, payload unmarshalling, and retry/timeout behavior across the system.
> 
> **Overview**
> Introduces the core public API surface for Radish task processing: new `Task`/`Worker[T]` interfaces, `Workers` registry with alias support, and wrappers (`internal/worker` + `wrapper.go`) that adapt typed workers to an untyped runtime worker interface and JSON-unmarshal task payloads into `TaskInfo[T]`.
> 
> Adds initial persisted task models (`models.TaskMeta`, `AttemptErrors` with SQL scan/value for JSON storage) and wires in a minimal `Radish` constructor/config placeholder, plus a new `go.rtnl.ai/ulid` dependency for task IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b4b540ecc9805a8272244549fe2df74dd7c25a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->