### PR TITLE
Config and Executors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Install Staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
 
       - name: Cache Speedup
         uses: actions/cache@v4

--- a/config.go
+++ b/config.go
@@ -1,3 +1,52 @@
 package radish
 
-type Config struct{}
+import (
+	"database/sql"
+	"time"
+
+	"go.rtnl.ai/confire"
+)
+
+const Prefix = "radish"
+
+type Config struct {
+	DatabaseURL  string        `env:"DATABASE_URL" desc:"DSN to the postgres database to use for task persistence."`
+	ManagedDB    bool          `default:"false" split_words:"true" desc:"Do not connect to the database, use a provided connection instead."`
+	NumWorkers   int           `default:"8" split_words:"true" desc:"The number of workers to use for concurrent task processing."`
+	TaskRetries  int           `default:"3" split_words:"true" desc:"The number of times to retry a task if it fails."`
+	TaskTimeout  time.Duration `default:"60s" split_words:"true" desc:"The amount of time for a task to complete before it is cancelled and requeued."`
+	PollInterval time.Duration `default:"5s" split_words:"true" desc:"The interval to poll the database for new tasks."`
+	PollJitter   time.Duration `default:"125ms" split_words:"true" desc:"The jitter to add to the poll interval to prevent thundering herds."`
+	Retention    time.Duration `default:"24h" desc:"The duration to retain completed tasks in the database."`
+	Conn         *sql.DB       `ignored:"true" desc:"Provide a database connection rather than allowing radish to connect itself."`
+}
+
+func LoadConfig() (cfg Config, err error) {
+	if err = confire.Process(Prefix, &cfg); err != nil {
+		return cfg, err
+	}
+
+	// The Conn cannot be set from the environment, so make sure it is nil!
+	cfg.Conn = nil
+	return cfg, nil
+}
+
+func (c Config) Validate() (err error) {
+	if c.DatabaseURL == "" && !c.ManagedDB {
+		err = confire.Join(err, confire.Invalid("radish", "database_url", "either the database DSN or a connection must be provided (specify RADISH_MANAGED_DB=1)"))
+	}
+
+	if c.NumWorkers < 1 {
+		err = confire.Join(err, confire.Invalid("radish", "num_workers", "the number of workers must be at least 1"))
+	}
+
+	if c.TaskTimeout <= 0 {
+		err = confire.Join(err, confire.Required("radish", "timeout"))
+	}
+
+	if c.PollInterval <= 0 {
+		err = confire.Join(err, confire.Required("radish", "poll_interval"))
+	}
+
+	return err
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,1 +1,97 @@
 package radish_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/confire/contest"
+	"go.rtnl.ai/radish"
+)
+
+// The values in the test environment variables should result a configuration that is
+// equal to the validConfig variable when processed. Anytime a configuration value is
+// added to this package, it should be added to this map and have a non-default value
+// for testing and validation purposes.
+var testEnv = contest.Env{
+	"DATABASE_URL":         "postgres://radish:radish@localhost:5432/radish?sslmode=disable",
+	"RADISH_NUM_WORKERS":   "32",
+	"RADISH_TASK_RETRIES":  "5",
+	"RADISH_TASK_TIMEOUT":  "120s",
+	"RADISH_POLL_INTERVAL": "20s",
+	"RADISH_POLL_JITTER":   "50ms",
+	"RADISH_RETENTION":     "48h",
+}
+
+// Used for mock testing of the config.
+var mockEnv = contest.Env{
+	"RADISH_MANAGED_DB":    "true",
+	"RADISH_NUM_WORKERS":   "4",
+	"RADISH_TASK_RETRIES":  "2",
+	"RADISH_TASK_TIMEOUT":  "5s",
+	"RADISH_POLL_INTERVAL": "1s",
+	"RADISH_POLL_JITTER":   "5ms",
+	"RADISH_RETENTION":     "24h",
+}
+
+// This config should always pass validation and should match the testEnv.
+// For a minimal valid config for tests, use [conftest.Config] or [conftest.Unmarked].
+var validConfig = radish.Config{
+	DatabaseURL:  "postgres://radish:radish@localhost:5432/radish?sslmode=disable",
+	NumWorkers:   32,
+	TaskRetries:  5,
+	TaskTimeout:  120 * time.Second,
+	PollInterval: 20 * time.Second,
+	PollJitter:   50 * time.Millisecond,
+	Retention:    48 * time.Hour,
+	Conn:         nil,
+}
+
+func TestConfig(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		t.Cleanup(testEnv.Set())
+
+		conf, err := radish.LoadConfig()
+		require.NoError(t, err, "could not process config from environment")
+		require.Equal(t, validConfig, conf, "valid config should be equal to the expected valid config")
+	})
+
+	t.Run("Invalid", func(t *testing.T) {
+		t.Cleanup(testEnv.Set())
+
+		// Set the invalid environment variables one at a time and reset once the test is complete.
+		invalid := contest.Env{
+			"DATABASE_URL":         "",
+			"RADISH_NUM_WORKERS":   "0",
+			"RADISH_TASK_TIMEOUT":  "0s",
+			"RADISH_POLL_INTERVAL": "0s",
+		}
+
+		// The expected errors for each invalid environment variable.
+		errs := map[string]string{
+			"DATABASE_URL":         "invalid configuration: radish.database_url either the database DSN or a connection must be provided (specify RADISH_MANAGED_DB=1)",
+			"RADISH_NUM_WORKERS":   "invalid configuration: radish.num_workers the number of workers must be at least 1",
+			"RADISH_TASK_TIMEOUT":  "invalid configuration: radish.timeout is required but not set",
+			"RADISH_POLL_INTERVAL": "invalid configuration: radish.poll_interval is required but not set",
+		}
+
+		for key := range invalid {
+			cleanup := invalid.Set(key)
+			_, err := radish.LoadConfig()
+			require.EqualError(t, err, errs[key], "expected error for %s environment variable", key)
+			cleanup()
+		}
+	})
+}
+
+func mockConfig(t *testing.T) *radish.Config {
+	t.Helper()
+
+	t.Cleanup(mockEnv.Set())
+	cfg, err := radish.LoadConfig()
+	require.NoError(t, err)
+
+	cfg.Conn = &sql.DB{}
+	return &cfg
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,7 @@
+package radish
+
+// This function returns the internal workers map for testing purposes but is not
+// generally available as part of the public API.
+func (r *Radish) Workers() *Workers {
+	return r.workers
+}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module go.rtnl.ai/radish
 
-go 1.25.6
+go 1.26.1
 
 require (
 	github.com/stretchr/testify v1.11.1
+	go.rtnl.ai/confire v1.2.0
 	go.rtnl.ai/ulid v1.2.0
-	go.rtnl.ai/x v1.10.0
+	go.rtnl.ai/x v1.15.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.rtnl.ai/confire v1.2.0 h1:Q/UexW6tdaNwulwNOrzSFhgHEYMugg1jFPxWA6u1K7w=
+go.rtnl.ai/confire v1.2.0/go.mod h1:g1rNOgKnnC0eHPU4kNKzPvxZmkeexU0cbvgO/SHDoSU=
 go.rtnl.ai/ulid v1.2.0 h1:EwIst7WZVdCmbtbDmIrRB15q03Qe9hmHHbxNej0V/wI=
 go.rtnl.ai/ulid v1.2.0/go.mod h1:F95yPYwEEZdz5sM4GC6buziff6xD+7XVcGZ/8n37Cn0=
-go.rtnl.ai/x v1.10.0 h1:NaFXZkhLlAFygevskDwWYMlu2zF3U29j2cmEcAcfJl4=
-go.rtnl.ai/x v1.10.0/go.mod h1:ciQ9PaXDtZDznzBrGDBV2yTElKX3aJgtQfi6V8613bo=
+go.rtnl.ai/x v1.15.0 h1:tzMqlAXrwZ4CHNscAawlBbMjDvEwZxSu9AMxJB4CPOs=
+go.rtnl.ai/x v1.15.0/go.mod h1:ciQ9PaXDtZDznzBrGDBV2yTElKX3aJgtQfi6V8613bo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/radish.go
+++ b/radish.go
@@ -1,17 +1,162 @@
 package radish
 
+import (
+	"database/sql"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrNoDatabase = errors.New("no database connection or configuration provided")
+	ErrRunning    = errors.New("radish cannot be modified while running")
+)
+
 type Radish struct {
-	workers *Workers
+	mu        sync.RWMutex
+	wg        *sync.WaitGroup
+	conf      Config
+	workers   *Workers
+	conn      *sql.DB
+	executors []*executor
 }
 
-func New() (*Radish, error) {
+type executor struct {
+	conf    *Config
+	workers *Workers
+	conn    *sql.DB
+	stop    chan<- struct{}
+}
+
+func New(conf *Config) (_ *Radish, err error) {
+	// If no config is provided, load the config from the environment.
+	// Otherwise, validate the config in case it wasn't loaded from the environment.
+	if conf == nil {
+		var cfg Config
+		if cfg, err = LoadConfig(); err != nil {
+			return nil, err
+		}
+		conf = &cfg
+	} else {
+		if err = conf.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	// If using managed database, validate that a connection is provided.
+	if conf.ManagedDB && conf.Conn == nil {
+		return nil, ErrNoDatabase
+	}
+
 	return &Radish{
+		conf:      *conf,
+		executors: nil,
 		workers: &Workers{
 			workers: make(map[string]untypedWorker),
 		},
 	}, nil
 }
 
-func (r *Radish) Workers() *Workers {
-	return r.workers
+// Starts the radish executors each in their own goroutine with a copy of the config
+// and workers to execute tasks in parallel. Returns an error if radish is already running.
+func (r *Radish) Run() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.isRunning() {
+		return ErrRunning
+	}
+
+	// Connect to the database or use the provided database connection.
+	if r.conf.ManagedDB {
+		if r.conf.Conn == nil {
+			return ErrNoDatabase
+		}
+		r.conn = r.conf.Conn
+	} else {
+		// TODO: Connect to the database using the provided database URL.
+	}
+
+	// Create a wait group to wait for all executors to finish.
+	r.wg = &sync.WaitGroup{}
+	r.wg.Add(r.conf.NumWorkers)
+
+	// Create the executors with a copy of the config and workers to execute tasks in parallel.
+	for i := 0; i < r.conf.NumWorkers; i++ {
+		executor := &executor{conf: &r.conf, workers: r.workers, conn: r.conn}
+		r.executors = append(r.executors, executor)
+		executor.run(r.wg)
+	}
+
+	return nil
+}
+
+// Shuts down the radish executors and waits for them to finish processing all tasks.
+func (r *Radish) Shutdown() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.isRunning() {
+		return
+	}
+
+	// Signal all executors to stop.
+	for _, executor := range r.executors {
+		executor.shutdown()
+	}
+
+	// Wait until all executors have finished.
+	r.wg.Wait()
+
+	r.executors = nil
+	r.wg = nil
+	return
+}
+
+func (r *Radish) IsRunning() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.isRunning()
+}
+
+func (r *Radish) isRunning() bool {
+	return len(r.executors) > 0
+}
+
+//============================================================================
+// Executor
+//============================================================================
+
+func (e *executor) run(wg *sync.WaitGroup) {
+	// Create an unbuffered channel to signal the poll loop to stop.
+	// This channel should block until a signal is received.
+	stop := make(chan struct{})
+
+	// Execute the poll loop in a goroutine.
+	go func(stop <-chan struct{}, wg *sync.WaitGroup) {
+		defer wg.Done()
+		poll := time.NewTicker(e.conf.PollInterval)
+		defer poll.Stop()
+
+		// Poll for new tasks to execute
+		for {
+			select {
+			case <-stop:
+				return
+			case <-poll.C:
+				e.execute()
+			}
+		}
+	}(stop, wg)
+
+	// Store the stop channel for the executor to use to signal the poll loop to stop.
+	e.stop = stop
+}
+
+func (e *executor) shutdown() {
+	// Close the stop channel to signal the poll loop to stop and immediately return.
+	// so that the executor is not blocking sending signals to the other executors.
+	close(e.stop)
+}
+
+func (e *executor) execute() {
+	// TODO: implement task execution logic here.
 }

--- a/radish.go
+++ b/radish.go
@@ -108,7 +108,6 @@ func (r *Radish) Shutdown() {
 
 	r.executors = nil
 	r.wg = nil
-	return
 }
 
 func (r *Radish) IsRunning() bool {

--- a/radish.go
+++ b/radish.go
@@ -1,8 +1,17 @@
 package radish
 
 type Radish struct {
+	workers *Workers
 }
 
 func New() (*Radish, error) {
-	return &Radish{}, nil
+	return &Radish{
+		workers: &Workers{
+			workers: make(map[string]untypedWorker),
+		},
+	}, nil
+}
+
+func (r *Radish) Workers() *Workers {
+	return r.workers
 }

--- a/radish_test.go
+++ b/radish_test.go
@@ -8,10 +8,17 @@ import (
 )
 
 func TestRadish(t *testing.T) {
-	turnip, err := radish.New()
+	conf := mockConfig(t)
+
+	turnip, err := radish.New(conf)
 	require.NoError(t, err)
 
 	require.NoError(t, radish.Register(turnip, new(SleepWorker)))
 	require.NoError(t, radish.Register(turnip, new(SortWorker)))
 	require.NoError(t, radish.Register(turnip, new(RandomFailureWorker)))
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	t.Skip("not implemented yet")
+	// TODO: test that radish waits for all executors to finish before returning from shutdown.
 }

--- a/radish_test.go
+++ b/radish_test.go
@@ -1,1 +1,17 @@
 package radish_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish"
+)
+
+func TestRadish(t *testing.T) {
+	turnip, err := radish.New()
+	require.NoError(t, err)
+
+	require.NoError(t, radish.Register(turnip, new(SleepWorker)))
+	require.NoError(t, radish.Register(turnip, new(SortWorker)))
+	require.NoError(t, radish.Register(turnip, new(RandomFailureWorker)))
+}

--- a/worker.go
+++ b/worker.go
@@ -85,10 +85,20 @@ func (wf *workFunc[T]) Do(ctx context.Context, task *TaskInfo[T]) error {
 //============================================================================
 
 func Register[T Task](r *Radish, worker Worker[T]) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.isRunning() {
+		return ErrRunning
+	}
 	return AddWorkerSafe(r.workers, worker)
 }
 
 func MustRegister[T Task](r *Radish, worker Worker[T]) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.isRunning() {
+		panic(ErrRunning)
+	}
 	AddWorker(r.workers, worker)
 }
 

--- a/worker.go
+++ b/worker.go
@@ -84,6 +84,14 @@ func (wf *workFunc[T]) Do(ctx context.Context, task *TaskInfo[T]) error {
 // Workers Registration and Wrapper
 //============================================================================
 
+func Register[T Task](r *Radish, worker Worker[T]) error {
+	return AddWorkerSafe(r.workers, worker)
+}
+
+func MustRegister[T Task](r *Radish, worker Worker[T]) {
+	AddWorker(r.workers, worker)
+}
+
 func AddWorker[T Task](w *Workers, worker Worker[T]) {
 	if err := AddWorkerSafe(w, worker); err != nil {
 		panic(err)

--- a/worker_test.go
+++ b/worker_test.go
@@ -88,6 +88,40 @@ func TestWorkFunc(t *testing.T) {
 // Workers Tests
 //============================================================================
 
+func TestRegister(t *testing.T) {
+	conf := mockConfig(t)
+
+	t.Run("HappyPath", func(t *testing.T) {
+		tasks, err := radish.New(conf)
+
+		require.NoError(t, err)
+		require.False(t, tasks.IsRunning())
+		require.NoError(t, radish.Register(tasks, new(SleepWorker)))
+		require.NoError(t, radish.Register(tasks, new(SortWorker)))
+		require.NoError(t, radish.Register(tasks, new(RandomFailureWorker)))
+
+		workers := tasks.Workers()
+		require.Equal(t, 7, workers.Len())
+		require.True(t, workers.Has("sleep"))
+		require.True(t, workers.Has("sort"))
+		require.True(t, workers.Has("failchance"))
+	})
+
+	t.Run("Running", func(t *testing.T) {
+		// Cannot register tasks while the radish instance is running.
+		tasks, err := radish.New(conf)
+		require.NoError(t, err)
+
+		require.NoError(t, radish.Register(tasks, new(SleepWorker)))
+		tasks.Run()
+		defer tasks.Shutdown()
+
+		require.True(t, tasks.IsRunning())
+		err = radish.Register(tasks, new(SortWorker))
+		require.ErrorIs(t, err, radish.ErrRunning)
+	})
+}
+
 func TestWorkers(t *testing.T) {
 	t.Run("HappyPath", func(t *testing.T) {
 		workers := &radish.Workers{}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -54,8 +54,19 @@ func TestFactory(t *testing.T) {
 		wg.Add(1)
 		go func(task worker.Worker) {
 			defer wg.Done()
+
+			var ctx context.Context
+			if timeout := task.Timeout(); timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+			} else {
+				ctx = context.Background()
+			}
+
 			require.NoError(t, task.UnmarshalTask())
-			require.NoError(t, task.Do(context.Background()))
+			require.NoError(t, task.Do(ctx))
+			require.Nil(t, task.Retry())
 		}(task)
 	}
 


### PR DESCRIPTION
### Scope of changes

Working towards stateful postgres tasks.

### Estimated PR Size:

- [ ] Tiny
- [ ] Small
- [x] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new concurrency/lifecycle management (`Run`/`Shutdown`, locking, goroutines) and config validation paths that can affect task processing behavior and shutdown semantics. Database connection handling is partially stubbed (`TODO` for non-managed DB), so misconfiguration/runtime behavior changes are possible.
> 
> **Overview**
> Adds a real `Config` loaded from environment variables (via `confire`) with validation for DB settings and worker/poll timing, plus unit tests to lock in env parsing and error cases.
> 
> Reworks `Radish` into a stateful, concurrency-safe runtime: `New(*Config)` loads/validates config, `Run()` starts per-worker polling executors with a shared DB connection, and `Shutdown()` signals executors and waits for completion; worker registration is now done via `Register`/`MustRegister` and is blocked once running.
> 
> Updates CI and module metadata to Go `1.26.x`/`1.26.1`, adds `confire`, bumps `go.rtnl.ai/x`, and adjusts tests to respect per-task timeouts when executing wrapped workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876d5e560f0bf759a51767be38dbcf8cf4c5a045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->