### PR TITLE
Jitter Poll Interval

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go.rtnl.ai/confire"
+	"go.rtnl.ai/radish/jitter"
 )
 
 const Prefix = "radish"
@@ -46,6 +47,10 @@ func (c Config) Validate() (err error) {
 
 	if c.PollInterval <= 0 {
 		err = confire.Join(err, confire.Required("radish", "poll_interval"))
+	} else {
+		if jerr := jitter.Check(c.PollInterval, c.PollJitter); jerr != nil {
+			err = confire.Join(err, confire.Invalid("radish", "poll_jitter", "the poll interval and jitter must create a positive distribution range"))
+		}
 	}
 
 	return err

--- a/jitter/jitter.go
+++ b/jitter/jitter.go
@@ -1,0 +1,107 @@
+package jitter
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+)
+
+var (
+	ErrInvalidMeanInterval = errors.New("mean interval duration must be positive")
+	ErrInvalidSigma        = errors.New("standard deviation must create a positive distribution range")
+)
+
+type Ticker struct {
+	C      <-chan time.Time
+	cancel context.CancelFunc
+}
+
+func New(𝛍, 𝛔 time.Duration) (ticker *Ticker) {
+	var err error
+	if ticker, err = NewWithContext(context.Background(), 𝛍, 𝛔); err != nil {
+		panic(err)
+	}
+	return ticker
+}
+
+func NewWithContext(ctx context.Context, 𝛍, 𝛔 time.Duration) (_ *Ticker, err error) {
+	// Panic early if the distribution is invalid.
+	if err = Check(𝛍, 𝛔); err != nil {
+		return nil, err
+	}
+
+	// Add an internal cancel function to context to be stored for use in Stop.
+	ctx, cancel := context.WithCancel(ctx)
+
+	// Give the channel a 1 element time buffer.
+	c := make(chan time.Time, 1)
+
+	// Start the ticker in a goroutine.
+	go func(ctx context.Context, c chan<- time.Time) {
+		timer := time.NewTimer(Interval(𝛍, 𝛔)) // initial timer
+
+		for {
+			select {
+			case tc := <-timer.C:
+				// Reset the internal timer for the next duration.
+				timer.Reset(Interval(𝛍, 𝛔))
+
+				// Non-blocking rebroadcast of the tick
+				select {
+				case c <- tc:
+				default:
+				}
+			case <-ctx.Done():
+				// Stop the timer and drain its channel if needed.
+				if !timer.Stop() {
+					<-timer.C
+				}
+
+				// Exit the goroutine.
+				return
+			}
+		}
+	}(ctx, c)
+
+	return &Ticker{C: c, cancel: cancel}, nil
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+// Stop does not close the channel, to prevent a concurrent goroutine reading from the
+// channel from seeing an "tick" when it was the closing of the ticker.
+func (t *Ticker) Stop() {
+	t.cancel()
+}
+
+// Returns a random duration between 𝛍 - 3𝛔 and 𝛍 + 3𝛔.
+func Interval(𝛍 time.Duration, 𝛔 time.Duration) time.Duration {
+	// Try 8 times to get a positive sample.
+	for range 8 {
+		if sample := time.Duration(rand.NormFloat64()*float64(𝛔)) + 𝛍; sample > 0 {
+			return sample
+		}
+	}
+
+	// Fallback is to return the mean interval.
+	return 𝛍
+}
+
+// Check ensures that a positive distribution range can be created from the mean and
+// standard deviation in most cases.
+func Check(𝛍 time.Duration, 𝛔 time.Duration) error {
+	if 𝛍 <= 0 {
+		return ErrInvalidMeanInterval
+	}
+
+	if 𝛔 <= 0 {
+		return ErrInvalidSigma
+	}
+
+	// Capture 99.7% of the data (near total range)
+	if 𝛍-(3*time.Duration(𝛔)) <= 0 {
+		return ErrInvalidSigma
+	}
+
+	return nil
+}

--- a/jitter/jitter_test.go
+++ b/jitter/jitter_test.go
@@ -1,0 +1,69 @@
+package jitter_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/radish/jitter"
+)
+
+func TestJitter(t *testing.T) {
+	var wg sync.WaitGroup
+
+	ticker := jitter.New(500*time.Millisecond, 20*time.Millisecond)
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	time.AfterFunc(3*time.Second, func() {
+		defer wg.Done()
+		close(stop)
+	})
+
+	wg.Add(1)
+	intervals := make([]time.Time, 0, 256)
+	start := time.Now()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case tick := <-ticker.C:
+				intervals = append(intervals, tick)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	require.Greater(t, len(intervals), 4)
+	require.Less(t, len(intervals), 12)
+
+	for _, tick := range intervals {
+		delta := tick.Sub(start)
+		fmt.Printf("%s\n", delta)
+		start = tick
+	}
+}
+
+func TestInterval(t *testing.T) {
+	prev := time.Duration(0)
+	for range 256 {
+		sample := jitter.Interval(5*time.Second, 150*time.Millisecond)
+		require.Greater(t, sample, 0*time.Second)
+		require.Less(t, sample, 10*time.Second)
+		require.NotEqual(t, prev, sample)
+		prev = sample
+	}
+}
+
+func TestCheck(t *testing.T) {
+	require.NoError(t, jitter.Check(5*time.Second, 150*time.Millisecond))
+	require.ErrorIs(t, jitter.Check(0*time.Second, 150*time.Millisecond), jitter.ErrInvalidMeanInterval)
+	require.ErrorIs(t, jitter.Check(-10*time.Second, 150*time.Millisecond), jitter.ErrInvalidMeanInterval)
+	require.ErrorIs(t, jitter.Check(5*time.Second, -150*time.Millisecond), jitter.ErrInvalidSigma)
+	require.ErrorIs(t, jitter.Check(5*time.Second, 3*time.Second), jitter.ErrInvalidSigma)
+}

--- a/radish.go
+++ b/radish.go
@@ -4,7 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"sync"
-	"time"
+
+	"go.rtnl.ai/radish/jitter"
 )
 
 var (
@@ -132,7 +133,7 @@ func (e *executor) run(wg *sync.WaitGroup) {
 	// Execute the poll loop in a goroutine.
 	go func(stop <-chan struct{}, wg *sync.WaitGroup) {
 		defer wg.Done()
-		poll := time.NewTicker(e.conf.PollInterval)
+		poll := jitter.New(e.conf.PollInterval, e.conf.PollJitter)
 		defer poll.Stop()
 
 		// Poll for new tasks to execute


### PR DESCRIPTION
### Scope of changes

To prevent multiple concurrent accesses to the database, jitter the poll interval.

### Estimated PR Size:

- [ ] Tiny
- [x] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the executor polling cadence from a fixed `time.Ticker` to a randomized jittered ticker, which can affect task scheduling frequency and timing under load. Also introduces new concurrency/timer logic whose correctness impacts shutdown behavior and resource usage.
> 
> **Overview**
> Adds a new `jitter` package providing a `Ticker` that emits ticks at normally-distributed intervals around a mean, with validation to ensure the sampled range stays positive.
> 
> Executors now poll for work using this jittered ticker (`PollInterval` + `PollJitter`) instead of a fixed `time.Ticker`, and `Config.Validate` now rejects poll jitter settings that would produce invalid/negative intervals; includes unit tests covering interval sampling and parameter validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac2b82d7c0f4afefb8a8e1bddcc2d641965b7800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->