### PR TITLE
Database Connection and Queries

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+
+	"go.rtnl.ai/x/dsn"
+)
+
+const Postgres = "postgres"
+
+var (
+	mu   sync.RWMutex
+	conn *sql.DB
+)
+
+func Use(db *sql.DB) (err error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if conn != nil {
+		return ErrAlreadyConnected
+	}
+	conn = db
+
+	ctx, cancel := context.WithTimeout(context.Background(), initializeTimeout)
+	defer cancel()
+
+	if err = conn.PingContext(ctx); err != nil {
+		conn.Close()
+		return fmt.Errorf("could not ping database: %w", err)
+	}
+
+	// Initialize the schema.
+	if err = initializeSchema(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Connect(databaseURL string) (err error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if conn != nil {
+		return ErrAlreadyConnected
+	}
+
+	var uri *dsn.DSN
+	if uri, err = dsn.Parse(databaseURL); err != nil {
+		return err
+	}
+
+	if uri.Provider != Postgres {
+		return fmt.Errorf("unsupported database provider: %s", uri.Provider)
+	}
+
+	var (
+		connStr string
+		opts    *PostgresOptions
+	)
+	if connStr, opts, err = ConnectionOptions(*uri); err != nil {
+		return err
+	}
+
+	if conn, err = sql.Open(Postgres, connStr); err != nil {
+		return err
+	}
+
+	// Apply any options to the connection string.
+	conn.SetMaxIdleConns(opts.MaxIdleConns)
+	conn.SetMaxOpenConns(opts.MaxOpenConns)
+	conn.SetConnMaxLifetime(opts.ConnMaxLifetime)
+	conn.SetConnMaxIdleTime(opts.ConnMaxIdleTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), initializeTimeout)
+	defer cancel()
+
+	if err = conn.PingContext(ctx); err != nil {
+		conn.Close()
+		return fmt.Errorf("could not ping database: %w", err)
+	}
+
+	// Initialize the schema.
+	if err = initializeSchema(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Close() error {
+	mu.Lock()
+	defer mu.Unlock()
+	if conn == nil {
+		return nil
+	}
+
+	err := conn.Close()
+	conn = nil
+	return err
+}
+
+func ExecContext(ctx context.Context, query string, args ...any) (result sql.Result, err error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if conn == nil {
+		return nil, ErrNotConnected
+	}
+	if result, err = conn.ExecContext(ctx, query, args...); err != nil {
+		return nil, dbe(err)
+	}
+	return result, nil
+}
+
+func Begin() (*sql.Tx, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if conn == nil {
+		return nil, ErrNotConnected
+	}
+	return conn.Begin()
+}
+
+func BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if conn == nil {
+		return nil, ErrNotConnected
+	}
+	return conn.BeginTx(ctx, opts)
+}

--- a/db/errors.go
+++ b/db/errors.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/lib/pq"
+)
+
+var (
+	// Database constraint errors
+	ErrAlreadyExists    = errors.New("record already exists in the database")
+	ErrConstraint       = errors.New("a database constraint was violated")
+	ErrDBReference      = errors.New("missing id of foreign key reference")
+	ErrDeleteRestricted = errors.New("cannot delete record because other records depend on it")
+	ErrNotFound         = errors.New("record not found in the database")
+	ErrNotNull          = errors.New("cannot set a required field to null")
+	ErrReadOnly         = errors.New("database or transaction is read-only")
+	ErrAlreadyConnected = errors.New("database connection already established")
+	ErrNotConnected     = errors.New("database connection not established")
+)
+
+func dbe(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+
+	var pgErr *pq.Error
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505":
+			return ErrAlreadyExists
+		case "23503":
+			return ErrDBReference
+		case "23502":
+			return ErrNotNull
+		case "23000", "23514":
+			return ErrConstraint
+		case "23001":
+			return ErrDeleteRestricted
+		case "25006":
+			return ErrReadOnly
+		}
+	}
+
+	return fmt.Errorf("pgx error: %w", err)
+}

--- a/db/options.go
+++ b/db/options.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.rtnl.ai/x/dsn"
+)
+
+type PostgresOptions struct {
+	MaxIdleConns    int
+	MaxOpenConns    int
+	ConnMaxLifetime time.Duration
+	ConnMaxIdleTime time.Duration
+}
+
+var defaultOptions = map[string]string{
+	"sslmode":                   "prefer",
+	"connect_timeout":           "60",
+	"fallback_application_name": "radish",
+}
+
+func ConnectionOptions(dsn dsn.DSN) (connStr string, opts *PostgresOptions, err error) {
+	// Make a copy of the database URL to avoid modifying the original.
+	if dsn.Options == nil {
+		dsn.Options = make(map[string]string, 0)
+	}
+
+	// Add default parameter configuration if not provided.
+	for key, value := range defaultOptions {
+		if _, ok := dsn.Options[key]; !ok {
+			dsn.Options[key] = value
+		}
+	}
+
+	// Parse the options into a PostgresOptions struct.
+	opts = &PostgresOptions{
+		MaxIdleConns:    128,
+		MaxOpenConns:    512,
+		ConnMaxLifetime: 60 * time.Minute,
+		ConnMaxIdleTime: 6 * time.Minute,
+	}
+
+	if val, ok := dsn.Options["max_idle_conns"]; ok {
+		if opts.MaxIdleConns, err = strconv.Atoi(val); err != nil {
+			return "", nil, fmt.Errorf("could not parse max idle conns: %w", err)
+		}
+		delete(dsn.Options, "max_idle_conns")
+	}
+
+	if val, ok := dsn.Options["max_open_conns"]; ok {
+		if opts.MaxOpenConns, err = strconv.Atoi(val); err != nil {
+			return "", nil, fmt.Errorf("could not parse max open conns: %w", err)
+		}
+		delete(dsn.Options, "max_open_conns")
+	}
+
+	if val, ok := dsn.Options["conn_max_lifetime"]; ok {
+		if opts.ConnMaxLifetime, err = time.ParseDuration(val); err != nil {
+			return "", nil, fmt.Errorf("could not parse conn max lifetime: %w", err)
+		}
+		delete(dsn.Options, "conn_max_lifetime")
+	}
+
+	if val, ok := dsn.Options["conn_max_idle_time"]; ok {
+		if opts.ConnMaxIdleTime, err = time.ParseDuration(val); err != nil {
+			return "", nil, fmt.Errorf("could not parse conn max idle time: %w", err)
+		}
+		delete(dsn.Options, "conn_max_idle_time")
+	}
+
+	return dsn.String(), opts, nil
+}

--- a/db/schema.go
+++ b/db/schema.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"time"
+
+	"go.rtnl.ai/x/rlog"
+)
+
+const (
+	acquireMigrationLockSQL = `SELECT pg_advisory_lock($1);`
+	releaseMigrationLockSQL = `SELECT pg_advisory_unlock($1);`
+	initializeTimeout       = 90 * time.Second
+	AdvisoryLockID          = int64(4006367007158143198)
+)
+
+func initializeSchema(ctx context.Context) (err error) {
+	// Acquire a single connection so we can acquire an advisory lock.
+	var cur *sql.Conn
+	if cur, err = conn.Conn(ctx); err != nil {
+		return err
+	}
+	defer cur.Close()
+
+	// Acquire the advisory lock.
+	if _, err = cur.ExecContext(ctx, acquireMigrationLockSQL, AdvisoryLockID); err != nil {
+		return err
+	}
+
+	// Ensure the advisory lock is released.
+	defer func() {
+		if _, err := conn.ExecContext(ctx, releaseMigrationLockSQL, AdvisoryLockID); err != nil {
+			rlog.ErrorAttrs(ctx, "could not release advisory lock", slog.Any("err", err))
+		}
+	}()
+
+	// Load the schema.
+	var schema string
+	if schema, err = Query("schema"); err != nil {
+		return err
+	}
+
+	// Execute the schema.
+	if _, err = cur.ExecContext(ctx, schema); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/db/sql.go
+++ b/db/sql.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"embed"
+	"strings"
+)
+
+// SQL contains the query statements for the database, written in SQL files
+// for ease of management for larger queries.
+//
+//go:embed sql/*.sql
+var queries embed.FS
+
+// Load a query from the SQL directory.
+func Query(name string) (string, error) {
+	if !strings.HasSuffix(name, ".sql") {
+		name += ".sql"
+	}
+
+	query, err := queries.ReadFile("sql/" + name)
+	if err != nil {
+		return "", err
+	}
+	return string(query), nil
+}

--- a/db/sql/cancel.sql
+++ b/db/sql/cancel.sql
@@ -1,0 +1,7 @@
+-- Mark a task as cancelled with no additional errors.
+UPDATE radish_tasks
+SET status = 'cancelled',
+    visible_at = NULL,
+    finished = NOW(),
+    modified = NOW()
+WHERE id = $1

--- a/db/sql/dequeue.sql
+++ b/db/sql/dequeue.sql
@@ -1,0 +1,20 @@
+-- Dequeue the next task from the queue, skipping over locked rows.
+-- Parameter: the visibility timeout for the task in seconds.
+WITH next_task AS (
+    SELECT id FROM radish_tasks
+    WHERE
+        status = 'pending' OR
+        (status in ('running', 'scheduled', 'retry') AND visible_at <= NOW())
+    ORDER BY created ASC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+)
+UPDATE radish_tasks
+SET status = 'running',
+    attempts = attempts + 1,
+    visible_at = NOW() + make_interval(secs := $1),
+    last_attempt = NOW(),
+    modified = NOW()
+FROM next_task
+WHERE radish_tasks.id = next_task.id
+RETURNING radish_tasks.*;

--- a/db/sql/enqueue.sql
+++ b/db/sql/enqueue.sql
@@ -1,0 +1,3 @@
+-- Enqueue a task with the given kind and payload.
+-- Parameter: the kind of task to enqueue and its JSON encoded payload.
+INSERT INTO radish_tasks (kind, payload) VALUES ($1, $2) RETURNING id;

--- a/db/sql/failed.sql
+++ b/db/sql/failed.sql
@@ -1,0 +1,8 @@
+-- Mark a task as failed with the given errors.
+UPDATE radish_tasks
+SET status = 'failed',
+    errors = $2,
+    visible_at = NULL,
+    finished = NOW(),
+    modified = NOW()
+WHERE id = $1

--- a/db/sql/retry.sql
+++ b/db/sql/retry.sql
@@ -1,0 +1,8 @@
+-- Mark a task as pending with the given errors and retry the task.
+-- Parameters: the task id, the errors to add to the task, and the delay before the next retry in seconds.
+UPDATE radish_tasks
+SET status = 'retry',
+    errors = $2
+    visible_at = NOW() + make_interval(secs := $3),
+    modified = NOW()
+WHERE id = $1;

--- a/db/sql/schedule.sql
+++ b/db/sql/schedule.sql
@@ -1,0 +1,4 @@
+-- Schedule a task with the given kind and payload to be executed later.
+-- Parameter: the kind of task to schedule and its JSON encoded payload and the timestamp when it should be executed after.
+INSERT INTO radish_tasks (kind, status, payload, visible_at)
+    VALUES ($1, 'scheduled', $2, $3) RETURNING id;

--- a/db/sql/schema.sql
+++ b/db/sql/schema.sql
@@ -1,0 +1,34 @@
+BEGIN;
+
+-- Create the radish_status type if it does not exist.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'radish_status') THEN
+        CREATE TYPE radish_status AS ENUM (
+            'pending',
+            'retry',
+            'scheduled',
+            'running',
+            'succeeded',
+            'failed',
+            'cancelled',
+        );
+    END IF;
+END $$;
+
+-- Create the radish_tasks table if it does not exist.
+CREATE TABLE IF NOT EXISTS radish_tasks (
+    id              BIGSERIAL PRIMARY KEY,
+    kind            VARCHAR(255) NOT NULL,
+    status          radish_status NOT NULL DEFAULT 'pending',
+    payload         JSONB NOT NULL DEFAULT '{}',
+    attempts        SMALLINT NOT NULL DEFAULT 0,
+    errors          JSONB NOT NULL DEFAULT '[]',
+    visible_at      TIMESTAMPTZ DEFAULT NULL,
+    last_attempt    TIMESTAMPTZ DEFAULT NULL,
+    finished        TIMESTAMPTZ DEFAULT NULL,
+    created         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    modified        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMIT;

--- a/db/sql/success.sql
+++ b/db/sql/success.sql
@@ -1,0 +1,7 @@
+-- Mark a task as succeeded with no additional errors.
+UPDATE radish_tasks
+SET status = 'succeeded',
+    visible_at = NULL,
+    finished = NOW(),
+    modified = NOW()
+WHERE id = $1

--- a/db/sql/vacuum.sql
+++ b/db/sql/vacuum.sql
@@ -1,0 +1,5 @@
+-- Cleanup any completed tasks that are older than the retention period.
+-- Parameter: the retention period in seconds.
+DELETE FROM radish_tasks WHERE
+    status IN ('succeeded', 'failed', 'cancelled') AND
+    finished < NOW() - make_interval(secs := $1);

--- a/db/sql_test.go
+++ b/db/sql_test.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuery(t *testing.T) {
+	query, err := Query("schema")
+	require.NoError(t, err)
+	require.NotEmpty(t, query)
+	require.True(t, strings.HasPrefix(query, "BEGIN;"))
+	require.True(t, strings.HasSuffix(query, "COMMIT;"))
+}
+
+func TestQueryInvalid(t *testing.T) {
+	query, err := Query("invalid")
+	require.Error(t, err)
+	require.Empty(t, query)
+}

--- a/export_test.go
+++ b/export_test.go
@@ -5,3 +5,10 @@ package radish
 func (r *Radish) Workers() *Workers {
 	return r.workers
 }
+
+// Mark the Radish struct as running for testing purposes but is not
+func (r *Radish) MarkRunning() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.executors = make([]*executor, 1)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module go.rtnl.ai/radish
 go 1.26.1
 
 require (
+	github.com/lib/pq v1.12.3
 	github.com/stretchr/testify v1.11.1
 	go.rtnl.ai/confire v1.2.0
-	go.rtnl.ai/ulid v1.2.0
 	go.rtnl.ai/x v1.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.rtnl.ai/confire v1.2.0 h1:Q/UexW6tdaNwulwNOrzSFhgHEYMugg1jFPxWA6u1K7w=
 go.rtnl.ai/confire v1.2.0/go.mod h1:g1rNOgKnnC0eHPU4kNKzPvxZmkeexU0cbvgO/SHDoSU=
-go.rtnl.ai/ulid v1.2.0 h1:EwIst7WZVdCmbtbDmIrRB15q03Qe9hmHHbxNej0V/wI=
-go.rtnl.ai/ulid v1.2.0/go.mod h1:F95yPYwEEZdz5sM4GC6buziff6xD+7XVcGZ/8n37Cn0=
 go.rtnl.ai/x v1.15.0 h1:tzMqlAXrwZ4CHNscAawlBbMjDvEwZxSu9AMxJB4CPOs=
 go.rtnl.ai/x v1.15.0/go.mod h1:ciQ9PaXDtZDznzBrGDBV2yTElKX3aJgtQfi6V8613bo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/models/task.go
+++ b/models/task.go
@@ -5,49 +5,41 @@ import (
 	"time"
 
 	"go.rtnl.ai/radish/status"
-	"go.rtnl.ai/ulid"
 )
 
 // TaskMeta is the properties of a task that are persisted in the database.
 type TaskMeta struct {
-	// ID of the task. A ULID that guarantees montonically increasing values.
-	ID ulid.ULID
+	// ID of the task.
+	ID int64
 
-	// Current attempt of the task. Attempts are inserted at 0, the number is
-	// incremented to 1 the first time it is worked, and it may be incremented further
-	// if it errors.
-	Attempt int
-
-	// Set of client IDs that have worked this job.
-	AttemptedBy []string
-
-	// Errors for each attempt that failed, ordered from earliest to latest.
-	Errors AttemptErrors
-
-	// Timestamp of when the task was completed successfully or failed.
-	Finished sql.NullTime
-
-	// Kind uniquely identifies the type of task and which worker is responsible for processing it.
+	// Kind uniquely identifies the type of task and which worker is responsible for processing it.// Kind uniquely identifies the type of task and which worker is responsible for processing it.
 	Kind string
 
-	// Timestamp of when the last attempt to work the task was started.
-	LastAttempt sql.NullTime
+	// Status of the task.
+	Status status.Status
 
 	// JSON encoded payload of the task.
 	Payload []byte
 
-	// The maximum number of attempts the task will be tried before it errors for the
-	// last time and will no longer be attempted.
-	Retries int
+	// Current attempt of the task. Attempts are inserted at 0, the number is
+	// incremented to 1 the first time it is worked, and it may be incremented further
+	// if it errors.
+	Attempts int16
 
-	// Status of the task.
-	Status status.Status
+	// Errors for each attempt that failed, ordered from earliest to latest.
+	Errors AttemptErrors
 
 	// Timestamp of when the task becomes visible to workers. This is used both for
 	// backoff delays in retries and for scheduling tasks in the future.
 	VisibleAt sql.NullTime
 
-	// Timestamp Metadata
+	// Timestamp of when the last attempt to work the task was started.
+	LastAttempt sql.NullTime
+
+	// Timestamp of when the task was completed successfully or failed.
+	Finished sql.NullTime
+
+	// Timestamp Metadata for record auditing and tracking.
 	Created  time.Time
 	Modified time.Time
 }

--- a/radish.go
+++ b/radish.go
@@ -1,10 +1,10 @@
 package radish
 
 import (
-	"database/sql"
 	"errors"
 	"sync"
 
+	"go.rtnl.ai/radish/db"
 	"go.rtnl.ai/radish/jitter"
 )
 
@@ -18,14 +18,12 @@ type Radish struct {
 	wg        *sync.WaitGroup
 	conf      Config
 	workers   *Workers
-	conn      *sql.DB
 	executors []*executor
 }
 
 type executor struct {
 	conf    *Config
 	workers *Workers
-	conn    *sql.DB
 	stop    chan<- struct{}
 }
 
@@ -72,9 +70,13 @@ func (r *Radish) Run() error {
 		if r.conf.Conn == nil {
 			return ErrNoDatabase
 		}
-		r.conn = r.conf.Conn
+		if err := db.Use(r.conf.Conn); err != nil {
+			return err
+		}
 	} else {
-		// TODO: Connect to the database using the provided database URL.
+		if err := db.Connect(r.conf.DatabaseURL); err != nil {
+			return err
+		}
 	}
 
 	// Create a wait group to wait for all executors to finish.
@@ -83,7 +85,7 @@ func (r *Radish) Run() error {
 
 	// Create the executors with a copy of the config and workers to execute tasks in parallel.
 	for i := 0; i < r.conf.NumWorkers; i++ {
-		executor := &executor{conf: &r.conf, workers: r.workers, conn: r.conn}
+		executor := &executor{conf: &r.conf, workers: r.workers}
 		r.executors = append(r.executors, executor)
 		executor.run(r.wg)
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -12,12 +12,12 @@ type Status uint8
 const (
 	StatusUnknown Status = iota
 	StatusPending
-	StatusRunning
-	StatusSuccess
-	StatusFailure
 	StatusRetry
-	StatusRevoked
 	StatusScheduled
+	StatusRunning
+	StatusSucceeded
+	StatusFailed
+	StatusCancelled
 
 	// The terminator is used to determine the last value of the enum.
 	statusTerminator
@@ -26,12 +26,12 @@ const (
 var statusNames = [8]string{
 	"unknown",
 	"pending",
-	"running",
-	"success",
-	"failure",
 	"retry",
-	"revoked",
 	"scheduled",
+	"running",
+	"succeeded",
+	"failed",
+	"cancelled",
 }
 
 func Parse(s any) (Status, error) {

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -16,22 +16,22 @@ var (
 	statusValues   = []status.Status{
 		status.StatusUnknown,
 		status.StatusPending,
-		status.StatusRunning,
-		status.StatusSuccess,
-		status.StatusFailure,
 		status.StatusRetry,
-		status.StatusRevoked,
 		status.StatusScheduled,
+		status.StatusRunning,
+		status.StatusSucceeded,
+		status.StatusFailed,
+		status.StatusCancelled,
 	}
 	statusStrings = []string{
 		"unknown",
 		"pending",
-		"running",
-		"success",
-		"failure",
 		"retry",
-		"revoked",
 		"scheduled",
+		"running",
+		"succeeded",
+		"failed",
+		"cancelled",
 	}
 )
 
@@ -144,7 +144,6 @@ func TestJSON(t *testing.T) {
 }
 
 func TestDatabase(t *testing.T) {
-	// TODO: implement scan and value tests
 	t.Run("VARCHAR", func(t *testing.T) {
 		// Ensure that all string representations are less than or equal to the db VARCHAR limit
 		for _, enum := range statusValues {

--- a/worker_test.go
+++ b/worker_test.go
@@ -113,8 +113,7 @@ func TestRegister(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NoError(t, radish.Register(tasks, new(SleepWorker)))
-		tasks.Run()
-		defer tasks.Shutdown()
+		tasks.MarkRunning()
 
 		require.True(t, tasks.IsRunning())
 		err = radish.Register(tasks, new(SortWorker))


### PR DESCRIPTION
### Scope of changes

Implements the database connection and queries.

### Estimated PR Size:

- [ ] Tiny
- [x] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Postgres connection layer and automatic schema initialization on startup, which can affect runtime database behavior and concurrency. Also changes persisted task identifiers/status values, which may impact compatibility with existing data and integrations.
> 
> **Overview**
> Adds a new `db` package that manages a singleton Postgres connection (`Connect`/`Use`/`Close`), applies pool settings from DSN options, normalizes common Postgres errors, and **auto-initializes the schema** under a Postgres advisory lock.
> 
> Introduces embedded SQL query files for task queue operations (enqueue/dequeue/schedule/retry/success/fail/cancel/vacuum) plus a `schema.sql` that creates the `radish_status` enum and `radish_tasks` table.
> 
> Wires `Radish.Run()` to use the new `db` package (removing per-executor `*sql.DB` storage), updates `models.TaskMeta` to use `int64` IDs and new persisted fields, and revises `status.Status` to the expanded set (`succeeded`/`failed`/`cancelled`). Adds targeted tests for SQL embedding and a testing-only `MarkRunning`, and adds `github.com/lib/pq` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cfc6ca166ea784e3e4198e5cf1f7642dd4a637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->